### PR TITLE
Quoting all the arguments would break the usage without arguments

### DIFF
--- a/bin/sweepwip
+++ b/bin/sweepwip
@@ -161,4 +161,4 @@ check_project() {
 
 export -f check_project # make this available for find
 
-find -L "${PROJECTS_DIR}"  -type d -name '.git' -exec bash -c "check_project '$*' -d '${PROJECTS_DIR}' -p '{}' " \;
+find -L "${PROJECTS_DIR}"  -type d -name '.git' -exec bash -c "check_project $* -d '${PROJECTS_DIR}' -p '{}' " \;


### PR DESCRIPTION
Removing the quote let you:

``` bash
sweepwip
```

as well as

``` bash
sweepwip -d repos
```
